### PR TITLE
Add webApiUrlPrefix to EvernoteSession and ENCredentials.

### DIFF
--- a/SampleApp/ViewController.m
+++ b/SampleApp/ViewController.m
@@ -50,6 +50,7 @@
                                                    otherButtonTitles:nil] autorelease];
             [alert show];
         } else {
+            NSLog(@"authenticated! noteStoreUrl:%@ webApiUrlPrefix:%@", session.noteStoreUrl, session.webApiUrlPrefix);
             [self updateButtonsForAuthentication];
         } 
     }];

--- a/UnitTests/EvernoteSessionTests.m
+++ b/UnitTests/EvernoteSessionTests.m
@@ -227,8 +227,7 @@
     STAssertNil(authenticationError, nil);
 
     // connection:didReceiveData:
-    // https%3A%2F%2Fsandbox.evernote.com%2Fedam%2Fnote%2Fshard%2Fs4
-    NSString *accessTokenResponseString = @"oauth_token=sometokenvalue&oauth_token_secret=&edam_noteStoreUrl=https%3A%2F%2Fsandbox.evernote.com%2Fedam%2Fnote%2Fshard%2Fs4&edam_userId=161";
+    NSString *accessTokenResponseString = @"oauth_token=sometokenvalue&oauth_token_secret=&edam_noteStoreUrl=https%3A%2F%2Fsandbox.evernote.com%2Fedam%2Fnote%2Fshard%2Fs4&edam_userId=161&edam_webApiUrlPrefix=https%3A%2F%2Fsandbox.evernote.com%2Fshard%2Fs1%2F";
     NSData *accessTokenResponseData = [accessTokenResponseString dataUsingEncoding:NSASCIIStringEncoding];
     [self.mockSession connection:self.dummyURLConnection didReceiveData:accessTokenResponseData];
     STAssertFalse(authenticationCompleted, nil);
@@ -237,7 +236,9 @@
     // connection:DidFinishLoading:
     // make sure EvernoteSession tried to save credentials
     [[self.mockSession expect] saveCredentialsWithEdamUserId:@"161" 
-                                                noteStoreUrl:@"https://sandbox.evernote.com/edam/note/shard/s4" authenticationToken:@"sometokenvalue"];
+                                                noteStoreUrl:@"https://sandbox.evernote.com/edam/note/shard/s4" 
+                                             webApiUrlPrefix:@"https://sandbox.evernote.com/shard/s1/"
+                                         authenticationToken:@"sometokenvalue"];
     [self.mockSession connectionDidFinishLoading:self.dummyURLConnection];    
     [self.mockSession verify];
     // and make sure our callback happened, without error.

--- a/evernote-sdk-ios/EvernoteSession.h
+++ b/evernote-sdk-ios/EvernoteSession.h
@@ -51,6 +51,17 @@ typedef void (^EvernoteAuthCompletionHandler)(NSError *error);
 // Will only be non-nil once we've authenticated.
 @property (nonatomic, readonly) NSString *authenticationToken;
 
+// URL for the Evernote UserStore.
+@property (nonatomic, readonly) NSString *userStoreUrl;
+
+// URL for the Evernote NoteStore for the authenticated user.
+// Will only be non-nil once we've authenticated.
+@property (nonatomic, readonly) NSString *noteStoreUrl;
+
+// URL prefix for the web API.
+// Will only be non-nil once we've authenticated.
+@property (nonatomic, readonly) NSString *webApiUrlPrefix;
+
 // Shared dispatch queue for API operations.
 @property (nonatomic, readonly) dispatch_queue_t queue;
 
@@ -98,6 +109,7 @@ typedef void (^EvernoteAuthCompletionHandler)(NSError *error);
 // Abstracted into a method to support unit testing.
 - (void)saveCredentialsWithEdamUserId:(NSString *)edamUserId 
                          noteStoreUrl:(NSString *)noteStoreUrl
+                      webApiUrlPrefix:(NSString *)webApiUrlPrefix
                   authenticationToken:(NSString *)authenticationToken;
 
 @end

--- a/evernote-sdk-ios/internal/ENCredentials.h
+++ b/evernote-sdk-ios/internal/ENCredentials.h
@@ -34,11 +34,13 @@
 @property (nonatomic, retain) NSString *host;
 @property (nonatomic, retain) NSString *edamUserId;
 @property (nonatomic, retain) NSString *noteStoreUrl;
+@property (nonatomic, retain) NSString *webApiUrlPrefix;
 @property (nonatomic, retain) NSString *authenticationToken;
 
 - (id)initWithHost:(NSString *)host
         edamUserId:(NSString *)edamUserId
-      noteStoreUrl:(NSString *)noteStoreUrl
+      noteStoreUrl:(NSString *)noteStoreUrl   
+   webApiUrlPrefix:(NSString *)webApiUrlPrefix
 authenticationToken:(NSString *)authenticationToken;
 
 - (BOOL)saveToKeychain;

--- a/evernote-sdk-ios/internal/ENCredentials.m
+++ b/evernote-sdk-ios/internal/ENCredentials.m
@@ -39,6 +39,7 @@
 @synthesize host = _host;
 @synthesize edamUserId = _edamUserId;
 @synthesize noteStoreUrl = _noteStoreUrl;
+@synthesize webApiUrlPrefix = _webApiUrlPrefix;
 @synthesize authenticationToken = _authenticationToken;
 
 - (void)dealloc
@@ -46,6 +47,7 @@
     [_host release];
     [_edamUserId release];
     [_noteStoreUrl release];
+    [_webApiUrlPrefix release];
     [_authenticationToken release];
     [super dealloc];
 }
@@ -53,6 +55,7 @@
 - (id)initWithHost:(NSString *)host
         edamUserId:(NSString *)edamUserId
       noteStoreUrl:(NSString *)noteStoreUrl
+   webApiUrlPrefix:(NSString *)webApiUrlPrefix
 authenticationToken:(NSString *)authenticationToken
 {
     self = [super init];
@@ -60,6 +63,7 @@ authenticationToken:(NSString *)authenticationToken
         self.host = host;
         self.edamUserId = edamUserId;
         self.noteStoreUrl = noteStoreUrl;
+        self.webApiUrlPrefix = webApiUrlPrefix;
         self.authenticationToken = authenticationToken;
     }
     return self;
@@ -101,6 +105,7 @@ authenticationToken:(NSString *)authenticationToken
     [encoder encodeObject:self.host forKey:@"host"];
     [encoder encodeObject:self.edamUserId forKey:@"edamUserId"];
     [encoder encodeObject:self.noteStoreUrl forKey:@"noteStoreUrl"];
+    [encoder encodeObject:self.webApiUrlPrefix forKey:@"webApiUrlPrefix"];
 }
 
 - (id)initWithCoder:(NSCoder *)decoder {
@@ -108,6 +113,7 @@ authenticationToken:(NSString *)authenticationToken
         self.host = [decoder decodeObjectForKey:@"host"];
         self.edamUserId = [decoder decodeObjectForKey:@"edamUserId"];
         self.noteStoreUrl = [decoder decodeObjectForKey:@"noteStoreUrl"];
+        self.webApiUrlPrefix = [decoder decodeObjectForKey:@"webApiUrlPrefix"];
     }
     return self;
 }


### PR DESCRIPTION
For the sandbox, this successfully retrieved a value like "https://sandbox.evernote.com/shard/s1/".
