### PR TITLE
Make EvernoteSession use an embedded UIViewController and UIWebView for OAuth authorization.

### DIFF
--- a/SampleApp/AppDelegate.m
+++ b/SampleApp/AppDelegate.m
@@ -34,9 +34,10 @@
     
     // Fill in the consumer key and secret with the values that you received from Evernote
     // To get an API key, visit http://dev.evernote.com/documentation/cloud/
-    NSString *CONSUMER_KEY = @"your key";
-    NSString *CONSUMER_SECRET = @"your secret";
-    
+//    NSString *CONSUMER_KEY = @"your key";
+//    NSString *CONSUMER_SECRET = @"your secret";
+    NSString *CONSUMER_KEY = @"mattmcglincy-7461";
+    NSString *CONSUMER_SECRET = @"9f023ce5ff2d76a4";
     // set up Evernote session singleton
     [EvernoteSession setSharedSessionHost:EVERNOTE_HOST 
                               consumerKey:CONSUMER_KEY 
@@ -70,14 +71,6 @@
 - (void)applicationWillTerminate:(UIApplication *)application
 {
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-}
-
-- (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url {
-    // delegate to the Evernote session singleton
-    if ([[EvernoteSession sharedSession] handleOpenURL:url]) {
-        return YES;
-    } 
-    return NO;
 }
 
 @end

--- a/SampleApp/AppDelegate.m
+++ b/SampleApp/AppDelegate.m
@@ -34,10 +34,9 @@
     
     // Fill in the consumer key and secret with the values that you received from Evernote
     // To get an API key, visit http://dev.evernote.com/documentation/cloud/
-//    NSString *CONSUMER_KEY = @"your key";
-//    NSString *CONSUMER_SECRET = @"your secret";
-    NSString *CONSUMER_KEY = @"mattmcglincy-7461";
-    NSString *CONSUMER_SECRET = @"9f023ce5ff2d76a4";
+    NSString *CONSUMER_KEY = @"your key";
+    NSString *CONSUMER_SECRET = @"your secret";
+
     // set up Evernote session singleton
     [EvernoteSession setSharedSessionHost:EVERNOTE_HOST 
                               consumerKey:CONSUMER_KEY 

--- a/SampleApp/SampleApp-Info.plist
+++ b/SampleApp/SampleApp-Info.plist
@@ -25,7 +25,9 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIMainStoryboardFile</key>
-	<string>MainStoryboard</string>
+	<string>iPhone</string>
+	<key>UIMainStoryboardFile~ipad</key>
+	<string>iPad</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/SampleApp/SampleApp-Info.plist
+++ b/SampleApp/SampleApp-Info.plist
@@ -2,15 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>en-your key</string>
-			</array>
-		</dict>
-	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/SampleApp/ViewController.m
+++ b/SampleApp/ViewController.m
@@ -41,7 +41,7 @@
 - (IBAction)authenticate:(id)sender 
 {
     EvernoteSession *session = [EvernoteSession sharedSession];
-    [session authenticateWithCompletionHandler:^(NSError *error) {
+    [session authenticateWithViewController:self completionHandler:^(NSError *error) {
         if (error || !session.isAuthenticated) {
             UIAlertView *alert = [[[UIAlertView alloc] initWithTitle:@"Error" 
                                                              message:@"Could not authenticate" 

--- a/SampleApp/en.lproj/iPad.storyboard
+++ b/SampleApp/en.lproj/iPad.storyboard
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="1.1" toolsVersion="2182" systemVersion="11E53" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" initialViewController="8Fh-DE-MR7">
+    <dependencies>
+        <deployment defaultVersion="1296" identifier="iOS"/>
+        <development defaultVersion="4200" identifier="xcode"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="1181"/>
+    </dependencies>
+    <scenes>
+        <!--I Pad View Controller-->
+        <scene sceneID="SUm-ZI-vnh">
+            <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="a69-l1-EQJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <viewController id="8Fh-DE-MR7" customClass="iPadViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="WiM-na-RgE">
+                        <rect key="frame" x="0.0" y="20" width="768" height="1004"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="S4Z-RV-NoF">
+                                <rect key="frame" x="170" y="730" width="133" height="37"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                <state key="normal" title="Authenticate">
+                                    <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <state key="highlighted">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="authenticate:" destination="8Fh-DE-MR7" eventType="touchUpInside" id="fNM-V3-P79"/>
+                                </connections>
+                            </button>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="zQ8-8C-KAm">
+                                <rect key="frame" x="145" y="246" width="478" height="440"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <prototypes>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="blue" indentationWidth="10" reuseIdentifier="NotebookTableCell" id="Tll-sz-Iu6">
+                                        <rect key="frame" x="0.0" y="22" width="478" height="44"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="478" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                    </tableViewCell>
+                                </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="8Fh-DE-MR7" id="GLo-J8-4gv"/>
+                                    <outlet property="delegate" destination="8Fh-DE-MR7" id="zxV-l0-nVm"/>
+                                </connections>
+                            </tableView>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Simple iPad Authentication Example" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" adjustsFontSizeToFit="NO" id="Sc3-ht-cNf">
+                                <rect key="frame" x="190" y="57" width="390" height="47"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="Un6-xb-xwa">
+                                <rect key="frame" x="466" y="730" width="133" height="37"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                <state key="normal" title="List Notebooks">
+                                    <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <state key="highlighted">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="listNotebooks:" destination="8Fh-DE-MR7" eventType="touchUpInside" id="AQa-em-zLi"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="xfd-Tt-EsV">
+                                <rect key="frame" x="319" y="730" width="133" height="37"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                <state key="normal" title="Logout">
+                                    <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <state key="highlighted">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="logout:" destination="8Fh-DE-MR7" eventType="touchUpInside" id="w7D-Wz-aHQ"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Authenticate, then list notebooks" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" id="buC-zp-kNz">
+                                <rect key="frame" x="259" y="806" width="251" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="0.35686275360000003" green="0.7019608021" blue="0.26274511220000002" alpha="1" colorSpace="deviceRGB"/>
+                    </view>
+                    <connections>
+                        <outlet property="authenticateButton" destination="S4Z-RV-NoF" id="gNo-v8-pvU"/>
+                        <outlet property="listNotebooksButton" destination="Un6-xb-xwa" id="cbG-Mb-iQa"/>
+                        <outlet property="logoutButton" destination="xfd-Tt-EsV" id="yqo-iI-tuC"/>
+                        <outlet property="tableView" destination="zQ8-8C-KAm" id="W5h-Cg-2ij"/>
+                    </connections>
+                </viewController>
+            </objects>
+            <point key="canvasLocation" x="-742" y="-531"/>
+        </scene>
+    </scenes>
+    <classes>
+        <class className="iPadViewController" superclassName="UIViewController">
+            <source key="sourceIdentifier" type="project" relativePath="./Classes/iPadViewController.h"/>
+            <relationships>
+                <relationship kind="action" name="authenticate:"/>
+                <relationship kind="action" name="listNotebooks:"/>
+                <relationship kind="action" name="logout:"/>
+                <relationship kind="outlet" name="authenticateButton" candidateClass="UIButton"/>
+                <relationship kind="outlet" name="listNotebooksButton" candidateClass="UIButton"/>
+                <relationship kind="outlet" name="logoutButton" candidateClass="UIButton"/>
+                <relationship kind="outlet" name="tableView" candidateClass="UITableView"/>
+            </relationships>
+        </class>
+    </classes>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar" statusBarStyle="blackTranslucent"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination"/>
+    </simulatedMetricsContainer>
+</document>

--- a/SampleApp/en.lproj/iPhone.storyboard
+++ b/SampleApp/en.lproj/iPhone.storyboard
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="1.1" toolsVersion="2182" systemVersion="11D50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="2">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="1.1" toolsVersion="2182" systemVersion="11E53" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="2">
     <dependencies>
         <deployment defaultVersion="1296" identifier="iOS"/>
         <development defaultVersion="4200" identifier="xcode"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="1181"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--I Phone View Controller-->
         <scene sceneID="5">
             <objects>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4" sceneMemberID="firstResponder"/>
-                <viewController id="2" customClass="ViewController" sceneMemberID="viewController">
+                <viewController id="2" customClass="iPhoneViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="3">
                         <rect key="frame" x="0.0" y="20" width="320" height="460"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -88,8 +88,8 @@
         </scene>
     </scenes>
     <classes>
-        <class className="ViewController" superclassName="UIViewController">
-            <source key="sourceIdentifier" type="project" relativePath="./Classes/ViewController.h"/>
+        <class className="iPhoneViewController" superclassName="UIViewController">
+            <source key="sourceIdentifier" type="project" relativePath="./Classes/iPhoneViewController.h"/>
             <relationships>
                 <relationship kind="action" name="authenticate:"/>
                 <relationship kind="action" name="listNotes:"/>

--- a/SampleApp/iPadViewController.h
+++ b/SampleApp/iPadViewController.h
@@ -1,0 +1,22 @@
+//
+//  iPadViewController.h
+//  evernote-sdk-ios
+//
+//  Created by Matthew McGlincy on 6/12/12.
+//  Copyright (c) 2012 n/a. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface iPadViewController : UIViewController <UITableViewDataSource, UITableViewDataSource>
+
+- (IBAction)authenticate:(id)sender;
+- (IBAction)listNotebooks:(id)sender;
+- (IBAction)logout:(id)sender;
+
+@property (retain, nonatomic) IBOutlet UIButton *authenticateButton;
+@property (retain, nonatomic) IBOutlet UIButton *listNotebooksButton;
+@property (retain, nonatomic) IBOutlet UITableView *tableView;
+@property (retain, nonatomic) IBOutlet UIButton *logoutButton;
+
+@end

--- a/SampleApp/iPadViewController.m
+++ b/SampleApp/iPadViewController.m
@@ -1,0 +1,153 @@
+//
+//  iPadViewController.m
+//  evernote-sdk-ios
+//
+//  Created by Matthew McGlincy on 6/12/12.
+//  Copyright (c) 2012 n/a. All rights reserved.
+//
+
+#import "EvernoteSDK.h"
+#import "iPadViewController.h"
+
+@interface iPadViewController ()
+
+@property (nonatomic, strong) NSArray *notebooks;
+
+@end
+
+@implementation iPadViewController
+
+@synthesize authenticateButton = _authenticateButton;
+@synthesize listNotebooksButton = _listNotebooksButton;
+@synthesize tableView = _tableView;
+@synthesize logoutButton = _logoutButton;
+@synthesize notebooks = _notebooks;
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self) {
+        // Custom initialization
+    }
+    return self;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+	// Do any additional setup after loading the view.
+    [self updateButtonsForAuthentication];
+}
+
+- (void)viewDidUnload
+{
+    [self setTableView:nil];
+    [self setAuthenticateButton:nil];
+    [self setListNotebooksButton:nil];
+    [self setLogoutButton:nil];
+    [super viewDidUnload];
+    // Release any retained subviews of the main view.
+}
+
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
+{
+	return YES;
+}
+
+- (IBAction)authenticate:(id)sender 
+{
+    EvernoteSession *session = [EvernoteSession sharedSession];
+    [session authenticateWithViewController:self completionHandler:^(NSError *error) {
+        if (error || !session.isAuthenticated) {
+            UIAlertView *alert = [[[UIAlertView alloc] initWithTitle:@"Error" 
+                                                             message:@"Could not authenticate" 
+                                                            delegate:nil 
+                                                   cancelButtonTitle:@"OK" 
+                                                   otherButtonTitles:nil] autorelease];
+            [alert show];
+        } else {
+            NSLog(@"authenticated! noteStoreUrl:%@ webApiUrlPrefix:%@", session.noteStoreUrl, session.webApiUrlPrefix);
+            [self updateButtonsForAuthentication];
+        } 
+    }];
+}
+
+- (IBAction)listNotebooks:(id)sender {
+    EvernoteNoteStore *noteStore = [EvernoteNoteStore noteStore];
+    [noteStore listNotebooksWithSuccess:^(NSArray *notebooks) {
+        self.notebooks = notebooks;
+        [self.tableView reloadData];
+    }
+                                failure:^(NSError *error) {
+                                    NSLog(@"error %@", error);                                            
+                                }];
+}
+
+- (IBAction)logout:(id)sender {
+    [[EvernoteSession sharedSession] logout];
+    [self updateButtonsForAuthentication];
+    self.notebooks = nil;
+    [self.tableView reloadData];
+}
+
+- (void)updateButtonsForAuthentication 
+{    
+    EvernoteSession *session = [EvernoteSession sharedSession];
+    
+    if (session.isAuthenticated) {
+        self.authenticateButton.enabled = NO;
+        self.authenticateButton.alpha = 0.5;
+        self.listNotebooksButton.enabled = YES;
+        self.listNotebooksButton.alpha = 1.0;
+        self.logoutButton.enabled = YES;
+        self.logoutButton.alpha = 1.0; 
+    } else {
+        self.authenticateButton.enabled = YES;
+        self.authenticateButton.alpha = 1.0;
+        self.listNotebooksButton.enabled = NO;
+        self.listNotebooksButton.alpha = 0.5;
+        self.logoutButton.enabled = NO;
+        self.logoutButton.alpha = 0.5;
+    }
+}
+
+- (void)dealloc {
+    [_tableView release];
+    [_notebooks release];
+    [_authenticateButton release];
+    [_listNotebooksButton release];
+    [_logoutButton release];
+    [super dealloc];
+}
+
+#pragma mark - Table view data source
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
+{
+    return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+    return self.notebooks.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    EDAMNotebook *notebook = [self.notebooks objectAtIndex:indexPath.row];
+    
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"NotebookTableCell"];
+    cell.textLabel.text = notebook.name;
+    cell.detailTextLabel.text = @"";
+    
+    return cell;
+}
+
+
+#pragma mark - Table view delegate
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+}
+
+@end

--- a/SampleApp/iPhoneViewController.h
+++ b/SampleApp/iPhoneViewController.h
@@ -1,5 +1,5 @@
 //
-//  ViewController.h
+//  iPhoneViewController.h
 //  OAuthTest
 //
 //  Created by Matthew McGlincy on 3/17/12.
@@ -7,7 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface ViewController : UIViewController
+@interface iPhoneViewController : UIViewController
 - (IBAction)authenticate:(id)sender;
 - (IBAction)listNotes:(id)sender;
 - (IBAction)logout:(id)sender;

--- a/SampleApp/iPhoneViewController.m
+++ b/SampleApp/iPhoneViewController.m
@@ -1,15 +1,15 @@
 //
-//  ViewController.m
+//  iPhoneViewController.m
 //  OAuthTest
 //
 //  Created by Matthew McGlincy on 3/17/12.
 //
 
 #import "EvernoteSDK.h"
-#import "ViewController.h"
+#import "iPhoneViewController.h"
 
 
-@implementation ViewController
+@implementation iPhoneViewController
 
 @synthesize userLabel;
 @synthesize listNotebooksButton;

--- a/UnitTests/EvernoteSessionTests.m
+++ b/UnitTests/EvernoteSessionTests.m
@@ -49,7 +49,6 @@
 
     // mock out our verification methods, since we don't care
     [[self.mockSession stub] verifyConsumerKeyAndSecret];
-    [[self.mockSession stub] verifyCFBundleURLSchemes];
     
     // mock out our connection-making method to return a dummy
     self.dummyURLConnection = [[[NSURLConnection alloc] 
@@ -69,7 +68,7 @@
 
     // make sure not setting consumer key, secret throws an exception
     @try {
-        [session authenticateWithCompletionHandler:^(NSError *error) {}];
+        [session authenticateWithViewController:nil completionHandler:^(NSError *error) {}];
         STFail(@"Should have thrown NSException");
     }
     @catch (NSException *expected) {
@@ -80,14 +79,7 @@
     session.host = @"foo";
     session.consumerKey = @"dummyaccount-1234";
     session.consumerSecret = @"123456789";
-    @try {
-        [session authenticateWithCompletionHandler:^(NSError *error) {}];
-        STFail(@"Should have thrown NSException");
-    }
-    @catch (NSException *expected) {
-        STAssertEqualObjects(expected.description, 
-                             @"Please add valid CFBundleURLTypes and CFBundleURLSchemes to your app's Info.plist.", nil);
-    }
+    [session authenticateWithViewController:nil completionHandler:^(NSError *error) {}];
 }
 
 // Make sure a nil NSURLConnection causes a proper error calback.
@@ -95,7 +87,7 @@
 {
     [[[self.mockSession stub] andReturn:nil] connectionWithRequest:[OCMArg any]];
 
-    [self.mockSession authenticateWithCompletionHandler:^(NSError *error) {
+    [self.mockSession authenticateWithViewController:nil completionHandler:^(NSError *error) {
         authenticationCompleted = YES;
         authenticationError = error;
     }];
@@ -111,7 +103,7 @@
 {    
     [[[self.mockSession stub] andReturn:self.dummyURLConnection] connectionWithRequest:[OCMArg any]];
 
-    [self.mockSession authenticateWithCompletionHandler:^(NSError *error) {
+    [self.mockSession authenticateWithViewController:nil completionHandler:^(NSError *error) {
         authenticationCompleted = YES;
         authenticationError = error;
     }];
@@ -127,7 +119,7 @@
 {
     [[[self.mockSession stub] andReturn:self.dummyURLConnection] connectionWithRequest:[OCMArg any]];
 
-    [self.mockSession authenticateWithCompletionHandler:^(NSError *error) {
+    [self.mockSession authenticateWithViewController:nil completionHandler:^(NSError *error) {
         authenticationCompleted = YES;
         authenticationError = error;
     }];
@@ -157,7 +149,7 @@
 {
     [[[self.mockSession stub] andReturn:self.dummyURLConnection] connectionWithRequest:[OCMArg any]];
 
-    [self.mockSession authenticateWithCompletionHandler:^(NSError *error) {
+    [self.mockSession authenticateWithViewController:nil completionHandler:^(NSError *error) {
         authenticationCompleted = YES;
         authenticationError = error;
     }];
@@ -187,7 +179,7 @@
 {
     [[[self.mockSession stub] andReturn:self.dummyURLConnection] connectionWithRequest:[OCMArg any]];
     
-    [self.mockSession authenticateWithCompletionHandler:^(NSError *error) {
+    [self.mockSession authenticateWithViewController:nil completionHandler:^(NSError *error) {
         authenticationCompleted = YES;
         authenticationError = error;
     }];
@@ -207,8 +199,8 @@
     STAssertFalse(authenticationCompleted, nil);
     STAssertNil(authenticationError, nil);
 
-    // make sure EvernoteSession tried to open the browser, for the Evernote authorization
-    [[self.mockSession expect] openBrowserWithURL:[OCMArg any]];
+    // make sure EvernoteSession tried to open the embedded viewController/browser for the Evernote authorization
+    [[self.mockSession expect] openOAuthViewControllerWithURL:[OCMArg any]];
 
     [self.mockSession connectionDidFinishLoading:self.dummyURLConnection];
     STAssertFalse(authenticationCompleted, nil);
@@ -216,8 +208,7 @@
     [self.mockSession verify];
     
     NSString *urlString = @"en-dummyaccount-1234://response?action=oauthCallback&oauth_token=en_oauth_test.12BF88D95B9.687474703A2F2F6C6F63616C686F73742F7E736574682F4544414D576562546573742F696E6465782E7068703F616374696F6E3D63616C6C6261636B.AEDE24F1FAFD67D267E78D27D14F01D3&oauth_verifier=0D6A636CD623302F8D69DBB8DF76D86E";
-    BOOL canOpen = [self.mockSession handleOpenURL:[NSURL URLWithString:urlString]];
-    STAssertTrue(canOpen, nil);
+    [self.mockSession oauthViewController:nil receivedOAuthCallbackURL:[NSURL URLWithString:urlString]];
     
     // now we can poke the NSURLConnectionDelegate methods again, for the 4th step of OAuth.
 

--- a/evernote-sdk-ios.xcodeproj/project.pbxproj
+++ b/evernote-sdk-ios.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		0B943F831525015500DB20A3 /* TTransportException.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B943F4E1525015500DB20A3 /* TTransportException.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0B943F841525015500DB20A3 /* TTransportException.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B943F4F1525015500DB20A3 /* TTransportException.m */; };
 		0B943F851525015500DB20A3 /* TTransportException.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B943F4F1525015500DB20A3 /* TTransportException.m */; };
+		0B94997E1585ADCF001A706A /* iPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0B94997C1585ADCF001A706A /* iPad.storyboard */; };
 		0B98592815432592007D7D37 /* ENAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B98592215432592007D7D37 /* ENAPI.h */; };
 		0B98592915432592007D7D37 /* ENAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B98592315432592007D7D37 /* ENAPI.m */; };
 		0B98592A15432592007D7D37 /* ENAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B98592315432592007D7D37 /* ENAPI.m */; };
@@ -67,6 +68,7 @@
 		0B98592E15432592007D7D37 /* ENCredentialStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B98592615432592007D7D37 /* ENCredentialStore.h */; };
 		0B98592F15432592007D7D37 /* ENCredentialStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B98592715432592007D7D37 /* ENCredentialStore.m */; };
 		0B98593015432592007D7D37 /* ENCredentialStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B98592715432592007D7D37 /* ENCredentialStore.m */; };
+		0BA8C63D15878823004C9D6A /* iPadViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BA8C63C15878823004C9D6A /* iPadViewController.m */; };
 		0BB3D1B11524ED96001C4534 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BB3D1B01524ED96001C4534 /* Foundation.framework */; };
 		0BB3D23A1524EE62001C4534 /* EDAM.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BB3D22D1524EE62001C4534 /* EDAM.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0BB3D23B1524EE62001C4534 /* EDAMLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BB3D22E1524EE62001C4534 /* EDAMLimits.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -87,8 +89,8 @@
 		0BB3D2781524EF37001C4534 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0BB3D2761524EF37001C4534 /* InfoPlist.strings */; };
 		0BB3D27A1524EF37001C4534 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BB3D2791524EF37001C4534 /* main.m */; };
 		0BB3D27E1524EF37001C4534 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BB3D27D1524EF37001C4534 /* AppDelegate.m */; };
-		0BB3D2811524EF37001C4534 /* MainStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0BB3D27F1524EF37001C4534 /* MainStoryboard.storyboard */; };
-		0BB3D2841524EF37001C4534 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BB3D2831524EF37001C4534 /* ViewController.m */; };
+		0BB3D2811524EF37001C4534 /* iPhone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0BB3D27F1524EF37001C4534 /* iPhone.storyboard */; };
+		0BB3D2841524EF37001C4534 /* iPhoneViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BB3D2831524EF37001C4534 /* iPhoneViewController.m */; };
 		0BB3D28E1524F01E001C4534 /* EvernoteSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BB3D2391524EE62001C4534 /* EvernoteSession.m */; };
 		0BB3D28F1524F01E001C4534 /* EDAMLimits.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BB3D22F1524EE62001C4534 /* EDAMLimits.m */; };
 		0BB3D2901524F01E001C4534 /* EDAMNoteStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BB3D2311524EE62001C4534 /* EDAMNoteStore.m */; };
@@ -148,12 +150,15 @@
 		0B943F4D1525015500DB20A3 /* TTransport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTransport.h; sourceTree = "<group>"; };
 		0B943F4E1525015500DB20A3 /* TTransportException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTransportException.h; sourceTree = "<group>"; };
 		0B943F4F1525015500DB20A3 /* TTransportException.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTransportException.m; sourceTree = "<group>"; };
+		0B94997D1585ADCF001A706A /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/iPad.storyboard; sourceTree = "<group>"; };
 		0B98592215432592007D7D37 /* ENAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ENAPI.h; sourceTree = "<group>"; };
 		0B98592315432592007D7D37 /* ENAPI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ENAPI.m; sourceTree = "<group>"; };
 		0B98592415432592007D7D37 /* ENCredentials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ENCredentials.h; sourceTree = "<group>"; };
 		0B98592515432592007D7D37 /* ENCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ENCredentials.m; sourceTree = "<group>"; };
 		0B98592615432592007D7D37 /* ENCredentialStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ENCredentialStore.h; sourceTree = "<group>"; };
 		0B98592715432592007D7D37 /* ENCredentialStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ENCredentialStore.m; sourceTree = "<group>"; };
+		0BA8C63B15878823004C9D6A /* iPadViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iPadViewController.h; sourceTree = "<group>"; };
+		0BA8C63C15878823004C9D6A /* iPadViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = iPadViewController.m; sourceTree = "<group>"; };
 		0BB3D1AD1524ED96001C4534 /* libevernote-sdk-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libevernote-sdk-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BB3D1B01524ED96001C4534 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		0BB3D1B41524ED96001C4534 /* evernote-sdk-ios-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "evernote-sdk-ios-Prefix.pch"; sourceTree = "<group>"; };
@@ -179,9 +184,9 @@
 		0BB3D27B1524EF37001C4534 /* SampleApp-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SampleApp-Prefix.pch"; sourceTree = "<group>"; };
 		0BB3D27C1524EF37001C4534 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		0BB3D27D1524EF37001C4534 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
-		0BB3D2801524EF37001C4534 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/MainStoryboard.storyboard; sourceTree = "<group>"; };
-		0BB3D2821524EF37001C4534 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
-		0BB3D2831524EF37001C4534 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		0BB3D2801524EF37001C4534 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/iPhone.storyboard; sourceTree = "<group>"; };
+		0BB3D2821524EF37001C4534 /* iPhoneViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iPhoneViewController.h; sourceTree = "<group>"; };
+		0BB3D2831524EF37001C4534 /* iPhoneViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iPhoneViewController.m; sourceTree = "<group>"; };
 		0BBA34A51537AF7D00DC7DD5 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		0BBA34A61537AFED00DC7DD5 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		0BBA34A71537B09300DC7DD5 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
@@ -422,9 +427,12 @@
 			children = (
 				0BB3D27C1524EF37001C4534 /* AppDelegate.h */,
 				0BB3D27D1524EF37001C4534 /* AppDelegate.m */,
-				0BB3D27F1524EF37001C4534 /* MainStoryboard.storyboard */,
-				0BB3D2821524EF37001C4534 /* ViewController.h */,
-				0BB3D2831524EF37001C4534 /* ViewController.m */,
+				0BB3D27F1524EF37001C4534 /* iPhone.storyboard */,
+				0B94997C1585ADCF001A706A /* iPad.storyboard */,
+				0BB3D2821524EF37001C4534 /* iPhoneViewController.h */,
+				0BB3D2831524EF37001C4534 /* iPhoneViewController.m */,
+				0BA8C63B15878823004C9D6A /* iPadViewController.h */,
+				0BA8C63C15878823004C9D6A /* iPadViewController.m */,
 				0BB3D2741524EF37001C4534 /* Supporting Files */,
 			);
 			path = SampleApp;
@@ -634,7 +642,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				0BB3D2781524EF37001C4534 /* InfoPlist.strings in Resources */,
-				0BB3D2811524EF37001C4534 /* MainStoryboard.storyboard in Resources */,
+				0BB3D2811524EF37001C4534 /* iPhone.storyboard in Resources */,
+				0B94997E1585ADCF001A706A /* iPad.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -710,7 +719,7 @@
 				0BB3D2931524F01E001C4534 /* EDAMErrors.m in Sources */,
 				0BB3D27A1524EF37001C4534 /* main.m in Sources */,
 				0BB3D27E1524EF37001C4534 /* AppDelegate.m in Sources */,
-				0BB3D2841524EF37001C4534 /* ViewController.m in Sources */,
+				0BB3D2841524EF37001C4534 /* iPhoneViewController.m in Sources */,
 				0B943F541525015500DB20A3 /* GCOAuth.m in Sources */,
 				0B943F571525015500DB20A3 /* NSData+Base64.m in Sources */,
 				0B943F5B1525015500DB20A3 /* NSString+URLEncoding.m in Sources */,
@@ -730,6 +739,7 @@
 				0B2B9D641544944800E5BD44 /* EvernoteUserStore.m in Sources */,
 				0B2B9D6A15449AEE00E5BD44 /* EvernoteSDK.m in Sources */,
 				0B0DE6A81571978C00D7347A /* ENOAuthViewController.m in Sources */,
+				0BA8C63D15878823004C9D6A /* iPadViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -744,6 +754,14 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
+		0B94997C1585ADCF001A706A /* iPad.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0B94997D1585ADCF001A706A /* en */,
+			);
+			name = iPad.storyboard;
+			sourceTree = "<group>";
+		};
 		0BB3D2761524EF37001C4534 /* InfoPlist.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -752,12 +770,12 @@
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
 		};
-		0BB3D27F1524EF37001C4534 /* MainStoryboard.storyboard */ = {
+		0BB3D27F1524EF37001C4534 /* iPhone.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
 				0BB3D2801524EF37001C4534 /* en */,
 			);
-			name = MainStoryboard.storyboard;
+			name = iPhone.storyboard;
 			sourceTree = "<group>";
 		};
 		0BDBBC4B1550A11A003E6681 /* InfoPlist.strings */ = {
@@ -848,7 +866,9 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "SampleApp/SampleApp-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -860,8 +880,10 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SampleApp/SampleApp-Prefix.pch";
 				INFOPLIST_FILE = "SampleApp/SampleApp-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/evernote-sdk-ios.xcodeproj/project.pbxproj
+++ b/evernote-sdk-ios.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B0DE6A61571978C00D7347A /* ENOAuthViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B0DE6A41571978C00D7347A /* ENOAuthViewController.h */; };
+		0B0DE6A71571978C00D7347A /* ENOAuthViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B0DE6A51571978C00D7347A /* ENOAuthViewController.m */; };
+		0B0DE6A81571978C00D7347A /* ENOAuthViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B0DE6A51571978C00D7347A /* ENOAuthViewController.m */; };
 		0B2B9D621544944800E5BD44 /* EvernoteUserStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B2B9D601544944800E5BD44 /* EvernoteUserStore.h */; };
 		0B2B9D631544944800E5BD44 /* EvernoteUserStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B2B9D611544944800E5BD44 /* EvernoteUserStore.m */; };
 		0B2B9D641544944800E5BD44 /* EvernoteUserStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B2B9D611544944800E5BD44 /* EvernoteUserStore.m */; };
@@ -109,6 +112,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0B0DE6A41571978C00D7347A /* ENOAuthViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ENOAuthViewController.h; sourceTree = "<group>"; };
+		0B0DE6A51571978C00D7347A /* ENOAuthViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ENOAuthViewController.m; sourceTree = "<group>"; };
 		0B2B9D601544944800E5BD44 /* EvernoteUserStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EvernoteUserStore.h; sourceTree = "<group>"; };
 		0B2B9D611544944800E5BD44 /* EvernoteUserStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EvernoteUserStore.m; sourceTree = "<group>"; };
 		0B2B9D6615449AEE00E5BD44 /* EvernoteSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EvernoteSDK.h; sourceTree = "<group>"; };
@@ -327,6 +332,8 @@
 				0B98592515432592007D7D37 /* ENCredentials.m */,
 				0B98592615432592007D7D37 /* ENCredentialStore.h */,
 				0B98592715432592007D7D37 /* ENCredentialStore.m */,
+				0B0DE6A41571978C00D7347A /* ENOAuthViewController.h */,
+				0B0DE6A51571978C00D7347A /* ENOAuthViewController.m */,
 			);
 			path = internal;
 			sourceTree = "<group>";
@@ -534,6 +541,7 @@
 				0B345EBE1544633F00A1FDBF /* EvernoteNoteStore.h in Headers */,
 				0B2B9D621544944800E5BD44 /* EvernoteUserStore.h in Headers */,
 				0B2B9D6815449AEE00E5BD44 /* EvernoteSDK.h in Headers */,
+				0B0DE6A61571978C00D7347A /* ENOAuthViewController.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -686,6 +694,7 @@
 				0B345EBF1544633F00A1FDBF /* EvernoteNoteStore.m in Sources */,
 				0B2B9D631544944800E5BD44 /* EvernoteUserStore.m in Sources */,
 				0B2B9D6915449AEE00E5BD44 /* EvernoteSDK.m in Sources */,
+				0B0DE6A71571978C00D7347A /* ENOAuthViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -720,6 +729,7 @@
 				0B345EC01544633F00A1FDBF /* EvernoteNoteStore.m in Sources */,
 				0B2B9D641544944800E5BD44 /* EvernoteUserStore.m in Sources */,
 				0B2B9D6A15449AEE00E5BD44 /* EvernoteSDK.m in Sources */,
+				0B0DE6A81571978C00D7347A /* ENOAuthViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -943,6 +953,7 @@
 				0BDBBC531550A11A003E6681 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/evernote-sdk-ios/EvernoteSDK.h
+++ b/evernote-sdk-ios/EvernoteSDK.h
@@ -34,6 +34,7 @@
 // For other application-level error codes, see EDAMErrorCode in EDAMErrors.h.
 typedef enum {
     EvernoteSDKErrorCode_TRANSPORT_ERROR = -3000,
+    EvernoteSDKErrorCode_NO_VIEWCONTROLLER = -3001,
 } EvernoteSDKErrorCode;
 
 // Evernote SDK NSError error domain.

--- a/evernote-sdk-ios/EvernoteSession.h
+++ b/evernote-sdk-ios/EvernoteSession.h
@@ -27,8 +27,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "EDAM.h"
+#import "ENOAuthViewController.h"
 
 // For Evernote-related error codes, see EDAMErrors.h
 
@@ -38,7 +39,7 @@ typedef void (^EvernoteAuthCompletionHandler)(NSError *error);
 /*
  * Evernote Session, using OAuth to authenticate.
  */
-@interface EvernoteSession : NSObject
+@interface EvernoteSession : NSObject <ENOAuthViewControllerDelegate>
 
 @property (nonatomic, retain) NSString *host;
 @property (nonatomic, retain) NSString *consumerKey;
@@ -75,11 +76,9 @@ typedef void (^EvernoteAuthCompletionHandler)(NSError *error);
 // Get the singleton shared session.
 + (EvernoteSession *)sharedSession;
 
-// URL handler. Call this from your AppDelegate's application:handleOpenURL: method.
-- (BOOL)handleOpenURL:(NSURL *)url;
-
 // Authenticate, calling the given handler upon completion.
-- (void)authenticateWithCompletionHandler:(EvernoteAuthCompletionHandler)completionHandler;
+- (void)authenticateWithViewController:(UIViewController *)viewController
+                     completionHandler:(EvernoteAuthCompletionHandler)completionHandler;
 
 // Clear authentication.
 - (void)logout;
@@ -100,11 +99,8 @@ typedef void (^EvernoteAuthCompletionHandler)(NSError *error);
 // Exposed for unit testing.
 - (void)verifyConsumerKeyAndSecret;
 
-// Exposed for unit testing.
-- (void)verifyCFBundleURLSchemes;
-
 // Abstracted into a method to support unit testing.
-- (void)openBrowserWithURL:(NSURL *)url;
+- (void)openOAuthViewControllerWithURL:(NSURL *)authorizationURL;
 
 // Abstracted into a method to support unit testing.
 - (void)saveCredentialsWithEdamUserId:(NSString *)edamUserId 

--- a/evernote-sdk-ios/EvernoteSession.m
+++ b/evernote-sdk-ios/EvernoteSession.m
@@ -60,6 +60,8 @@
 - (NSString *)oauthCallback;
 - (ENCredentials *)credentials;
 
+- (void)completeAuthenticationWithError:(NSError *)error;
+
 @end
 
 @implementation EvernoteSession
@@ -224,9 +226,12 @@
 - (void)authenticateWithViewController:(UIViewController *)viewController
                      completionHandler:(EvernoteAuthCompletionHandler)completionHandler
 {
+    self.viewController = viewController;
+    self.completionHandler = completionHandler;
+
     // authenticate is idempotent; check if we're already authenticated
     if (self.isAuthenticated) {
-        completionHandler(nil);
+        [self completeAuthenticationWithError:nil];
         return;
     }
     
@@ -234,9 +239,14 @@
     // This verification raises an NSException if problems are found.
     [self verifyConsumerKeyAndSecret];
 
-    self.viewController = viewController;
-    self.completionHandler = completionHandler;
-    
+    if (!viewController) {
+        // no point continuing without a valid view controller,
+        [self completeAuthenticationWithError:[NSError errorWithDomain:EvernoteSDKErrorDomain 
+                                                                  code:EvernoteSDKErrorCode_NO_VIEWCONTROLLER 
+                                                              userInfo:nil]];
+        return;
+    }
+        
     // start the OAuth dance to get credentials (auth token, noteStoreUrl, etc).
     [self startOauthAuthentication];    
 }
@@ -269,11 +279,9 @@
     NSURLConnection *connection = [self connectionWithRequest:tempTokenRequest];
     if (!connection) {
         // can't make connection, so immediately fail.
-        if (self.completionHandler) {
-            self.completionHandler([NSError errorWithDomain:EvernoteSDKErrorDomain 
+        [self completeAuthenticationWithError:[NSError errorWithDomain:EvernoteSDKErrorDomain 
                                                        code:EvernoteSDKErrorCode_TRANSPORT_ERROR 
-                                                   userInfo:nil]);
-        }
+                                                   userInfo:nil]];
     }
 }
 
@@ -329,11 +337,9 @@
     NSURLConnection *connection = [self connectionWithRequest:authTokenRequest];
     if (!connection) {
         // can't make connection, so immediately fail.
-        if (self.completionHandler) {
-            self.completionHandler([NSError errorWithDomain:EvernoteSDKErrorDomain 
+        [self completeAuthenticationWithError:[NSError errorWithDomain:EvernoteSDKErrorDomain 
                                                        code:EvernoteSDKErrorCode_TRANSPORT_ERROR 
-                                                   userInfo:nil]);
-        }
+                                                   userInfo:nil]];
     }
     
     return YES;
@@ -345,9 +351,7 @@
 {
     self.receivedData = nil;
     self.response = nil;
-    if (self.completionHandler) {
-        self.completionHandler(error);
-    }
+    [self completeAuthenticationWithError:error];
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response
@@ -375,11 +379,9 @@
         if (statusCode != 200) {
             NSLog(@"Received error HTTP response code: %d", statusCode);
             NSLog(@"%@", string);
-            if (self.completionHandler) {
-                self.completionHandler([NSError errorWithDomain:EvernoteSDKErrorDomain 
+            [self completeAuthenticationWithError:[NSError errorWithDomain:EvernoteSDKErrorDomain 
                                                            code:EvernoteSDKErrorCode_TRANSPORT_ERROR 
-                                                       userInfo:nil]);
-            }
+                                                       userInfo:nil]];
             self.receivedData = nil;
             self.response = nil;
             return;
@@ -411,11 +413,9 @@
         // If any of the fields are nil, we can't continue.
         // Assume an invalid response from the server.
         if (!authenticationToken || !noteStoreUrl || !edamUserId || !webApiUrlPrefix) {
-            if (self.completionHandler) {
-                self.completionHandler([NSError errorWithDomain:EvernoteSDKErrorDomain 
+            [self completeAuthenticationWithError:[NSError errorWithDomain:EvernoteSDKErrorDomain 
                                                            code:EDAMErrorCode_INTERNAL_ERROR 
-                                                       userInfo:nil]);
-            }
+                                                       userInfo:nil]];
         } else {        
             // add auth info to our credential store, saving to user defaults and keychain
             [self saveCredentialsWithEdamUserId:edamUserId 
@@ -424,9 +424,7 @@
                             authenticationToken:authenticationToken];
             
             // call our callback, without error.
-            if (self.completionHandler) {
-                self.completionHandler(nil);
-            }
+            [self completeAuthenticationWithError:nil];
         }
     }
 
@@ -461,6 +459,15 @@
                                              webApiUrlPrefix:webApiUrlPrefix
                                          authenticationToken:authenticationToken] autorelease];
     [self.credentialStore addCredentials:ec];    
+}
+
+- (void)completeAuthenticationWithError:(NSError *)error
+{
+    if (self.completionHandler) {
+        self.completionHandler(error);
+    }
+    self.completionHandler = nil;
+    self.viewController = nil;
 }
 
 #pragma mark - querystring parsing
@@ -501,10 +508,8 @@
 
 - (void)oauthViewController:(ENOAuthViewController *)sender didFailWithError:(NSError *)error
 {
-    [self.viewController dismissModalViewControllerAnimated:YES];    
-    if (self.completionHandler) {
-        self.completionHandler(error);
-    }
+    [self.viewController dismissModalViewControllerAnimated:YES];
+    [self completeAuthenticationWithError:error];
 }
 
 - (void)oauthViewController:(ENOAuthViewController *)sender receivedOAuthCallbackURL:(NSURL *)url
@@ -527,11 +532,9 @@
     NSURLConnection *connection = [self connectionWithRequest:authTokenRequest];
     if (!connection) {
         // can't make connection, so immediately fail.
-        if (self.completionHandler) {
-            self.completionHandler([NSError errorWithDomain:EvernoteSDKErrorDomain 
+        [self completeAuthenticationWithError:[NSError errorWithDomain:EvernoteSDKErrorDomain 
                                                        code:EvernoteSDKErrorCode_TRANSPORT_ERROR 
-                                                   userInfo:nil]);
-        }
+                                                   userInfo:nil]];
     }
 }
 

--- a/evernote-sdk-ios/internal/ENOAuthViewController.h
+++ b/evernote-sdk-ios/internal/ENOAuthViewController.h
@@ -1,0 +1,27 @@
+//
+//  ENOAuthViewController.h
+//  evernote-sdk-ios
+//
+//  Created by Matthew McGlincy on 5/26/12.
+//  Copyright (c) 2012 n/a. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class ENOAuthViewController;
+
+@protocol ENOAuthViewControllerDelegate <NSObject>
+- (void)oauthViewControllerDidCancel:(ENOAuthViewController *)sender;
+- (void)oauthViewController:(ENOAuthViewController *)sender didFailWithError:(NSError *)error;
+- (void)oauthViewController:(ENOAuthViewController *)sender receivedOAuthCallbackURL:(NSURL *)url;
+@end
+
+@interface ENOAuthViewController : UIViewController
+
+@property (nonatomic, assign) id<ENOAuthViewControllerDelegate> delegate;
+
+- (id)initWithAuthorizationURL:(NSURL *)authorizationURL 
+           oauthCallbackPrefix:(NSString *)oauthCallbackPrefix
+                      delegate:(id<ENOAuthViewControllerDelegate>)delegate;
+
+@end

--- a/evernote-sdk-ios/internal/ENOAuthViewController.m
+++ b/evernote-sdk-ios/internal/ENOAuthViewController.m
@@ -1,0 +1,118 @@
+//
+//  ENOAuthViewController.m
+//  evernote-sdk-ios
+//
+//  Created by Matthew McGlincy on 5/26/12.
+//  Copyright (c) 2012 n/a. All rights reserved.
+//
+
+#import "ENOAuthViewController.h"
+
+@interface ENOAuthViewController() <UIWebViewDelegate>
+
+@property (nonatomic, retain) NSURL *authorizationURL;
+@property (nonatomic, retain) NSString *oauthCallbackPrefix;
+@property (nonatomic, retain) UIWebView *webView;
+
+@end
+
+@implementation ENOAuthViewController
+
+@synthesize delegate = _delegate;
+@synthesize authorizationURL = _authorizationURL;
+@synthesize oauthCallbackPrefix = _oauthCallbackPrefix;
+@synthesize webView = _webView;
+
+- (void)dealloc
+{
+    self.delegate = nil;
+    [_authorizationURL release];
+    [_oauthCallbackPrefix release];
+    [_webView release];
+    [super dealloc];
+}
+
+- (id)initWithAuthorizationURL:(NSURL *)authorizationURL 
+           oauthCallbackPrefix:(NSString *)oauthCallbackPrefix
+                      delegate:(id<ENOAuthViewControllerDelegate>)delegate
+{
+    self = [super init];
+    if (self) {
+        self.authorizationURL = authorizationURL;
+        self.oauthCallbackPrefix = oauthCallbackPrefix;
+        self.delegate = delegate;
+    }
+    return self;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+	// Do any additional setup after loading the view.
+    
+    UIBarButtonItem *cancelItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel 
+                                                                                target:self action:@selector(cancel:)];
+    self.navigationItem.rightBarButtonItem = cancelItem;
+    
+    // Using self.view.frame leaves a 20px black space above the webview... from status bar spacing?
+    //self.webView = [[UIWebView alloc] initWithFrame:self.view.frame];
+    self.webView = [[UIWebView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height)];
+    self.webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.webView.scalesPageToFit = YES;
+    self.webView.delegate = self;
+    [self.view addSubview:self.webView];
+    [self.webView loadRequest:[NSURLRequest requestWithURL:self.authorizationURL]];
+}
+
+- (void)cancel:(id)sender
+{
+    [self.webView stopLoading];
+    if (self.delegate) {
+        [self.delegate oauthViewControllerDidCancel:self];
+    }
+}
+
+- (void)viewDidUnload
+{
+    [super viewDidUnload];
+
+    // Release any retained subviews of the main view.
+
+    self.webView.delegate = nil;
+    [self.webView stopLoading];    
+    [_webView release];
+}
+
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
+{
+    return YES;
+//    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+}
+
+# pragma mark - UIWebViewDelegate
+
+- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
+{
+    if ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102) {
+        // ignore "Frame load interrupted" errors, which we get as part of the final oauth callback :P
+        return;
+    }
+    
+    if (self.delegate) {
+        [self.delegate oauthViewController:self didFailWithError:error];
+    }
+}
+
+- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
+{
+    if ([[request.URL absoluteString] hasPrefix:self.oauthCallbackPrefix]) {
+        // this is our OAuth callback prefix, so let the delegate handle it
+        if (self.delegate) {
+            [self.delegate oauthViewController:self receivedOAuthCallbackURL:request.URL];
+        }
+        return NO;
+    }
+    return YES;
+}
+
+@end

--- a/evernote-sdk-ios/internal/ENOAuthViewController.m
+++ b/evernote-sdk-ios/internal/ENOAuthViewController.m
@@ -86,7 +86,6 @@
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
     return YES;
-//    return (interfaceOrientation == UIInterfaceOrientationPortrait);
 }
 
 # pragma mark - UIWebViewDelegate


### PR DESCRIPTION
Make EvernoteSession use an embedded UIViewController and UIWebView for OAuth authorization to Evernote, rather than using mobile Safari... since Apple has now decided this is forbidden and worthy worth of app rejection.

Please don't immediately merge this; I'd like to review it carefully and talk through it thoroughly before any merging... but the pull request makes it easier to get a pleasant-to-review diff of the changes :)
