### PR TITLE
Fixed a crash when the UIWebView fails to load with an error

### DIFF
--- a/evernote-sdk-ios/EvernoteSession.m
+++ b/evernote-sdk-ios/EvernoteSession.m
@@ -496,7 +496,10 @@
 
 - (void)oauthViewControllerDidCancel:(ENOAuthViewController *)sender
 {
-    [self.viewController dismissModalViewControllerAnimated:YES];    
+    [self.viewController dismissModalViewControllerAnimated:YES];
+    if (self.completionHandler) {
+        self.completionHandler(nil);
+    }
 }
 
 - (void)oauthViewController:(ENOAuthViewController *)sender didFailWithError:(NSError *)error

--- a/evernote-sdk-ios/internal/ENOAuthViewController.m
+++ b/evernote-sdk-ios/internal/ENOAuthViewController.m
@@ -88,7 +88,7 @@
         return;
     }
     
-    if (error.code == -999) {
+    if (error.code == NSURLErrorCancelled) {
         // ignore rapid repeated clicking
         return;
     }

--- a/evernote-sdk-ios/internal/ENOAuthViewController.m
+++ b/evernote-sdk-ios/internal/ENOAuthViewController.m
@@ -26,6 +26,7 @@
 - (void)dealloc
 {
     self.delegate = nil;
+    [self.webView stopLoading];
     [_authorizationURL release];
     [_oauthCallbackPrefix release];
     [_webView release];
@@ -70,17 +71,7 @@
     if (self.delegate) {
         [self.delegate oauthViewControllerDidCancel:self];
     }
-}
-
-- (void)viewDidUnload
-{
-    [super viewDidUnload];
-
-    // Release any retained subviews of the main view.
-
-    self.webView.delegate = nil;
-    [self.webView stopLoading];    
-    [_webView release];
+    self.delegate = nil;
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
@@ -97,6 +88,13 @@
         return;
     }
     
+    if (error.code == -999) {
+        // ignore rapid repeated clicking
+        return;
+    }
+    
+    [self.webView stopLoading];
+
     if (self.delegate) {
         [self.delegate oauthViewController:self didFailWithError:error];
     }


### PR DESCRIPTION
This currently leads to a crash because the webview is dismissed while it is still loading. The easiest way to make that happen is to press the login button twice, that will cause an error -999 because the previous request is still running. I also fixed that problem by simply ignoring that error. I think it would be better to fix this also in the OAuth website by having some JS disable the button once it starts to load.
