### PR TITLE
EvernoteSession logout should log the user out completely

### DIFF
--- a/evernote-sdk-ios/EvernoteSession.m
+++ b/evernote-sdk-ios/EvernoteSession.m
@@ -223,10 +223,9 @@
     [self.credentialStore delete];
     
     // remove all cookies from the Evernote service
-    NSHTTPCookie *cookie;
     NSHTTPCookieStorage *cookieJar = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    for (cookie in [cookieJar cookies]) {
-        if ([[cookie domain] isEqualToString: self.host]) {
+    for (NSHTTPCookie *cookie in [cookieJar cookies]) {
+        if ([[cookie domain] hasSuffix: self.host]) {
             [cookieJar deleteCookie: cookie];
         }
     }

--- a/evernote-sdk-ios/EvernoteSession.m
+++ b/evernote-sdk-ios/EvernoteSession.m
@@ -221,6 +221,15 @@
     
     // remove the store from user defaults
     [self.credentialStore delete];
+    
+    // remove all cookies from the Evernote service
+    NSHTTPCookie *cookie;
+    NSHTTPCookieStorage *cookieJar = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+    for (cookie in [cookieJar cookies]) {
+        if ([[cookie domain] isEqualToString: self.host]) {
+            [cookieJar deleteCookie: cookie];
+        }
+    }
 }
 
 - (void)authenticateWithViewController:(UIViewController *)viewController


### PR DESCRIPTION
We need to remove cookies for the Evernote service host so that the user is logged out of the UIWebView and must authenticate again if they re-auth. This is more secure and allows user switching.
