### PR TITLE
Fix retain cycles and missing autorelease pool. TODO: incomplete

### DIFF
--- a/evernote-sdk-ios/EvernoteNoteStore.m
+++ b/evernote-sdk-ios/EvernoteNoteStore.m
@@ -157,8 +157,9 @@
 - (void)listTagsWithSuccess:(void(^)(NSArray *tags))success
                     failure:(void(^)(NSError *error))failure
 {
+    __block EvernoteNoteStore *bself = self;
     [self invokeAsyncIdBlock:^id() {
-        return [self.noteStore listTags:self.session.authenticationToken];
+        return [bself.noteStore listTags:bself.session.authenticationToken];
     } success:success failure:failure];
 }
 
@@ -403,8 +404,9 @@ withResourcesAlternateData:(BOOL)withResourcesAlternateData
            success:(void(^)(EDAMNote *note))success
            failure:(void(^)(NSError *error))failure
 {
+    __block EvernoteNoteStore *bself = self;
     [self invokeAsyncIdBlock:^id() {
-        return [self.noteStore createNote:self.session.authenticationToken:note];
+        return [bself.noteStore createNote:bself.session.authenticationToken:note];
     } success:success failure:failure];
 }
 


### PR DESCRIPTION
It looks like there are a few retain cycles going with the blocks in the SDK.

The reason is that some of the blocks are retaining self (http://stackoverflow.com/a/4352616/283899)

This PR is incomplete, but this is an issue that was affecting us.
