### PR TITLE
Fix for llvm 4.0 string formatting warning.

### DIFF
--- a/evernote-sdk-ios/3rdParty/cocoa-oauth/GCOAuth.m
+++ b/evernote-sdk-ios/3rdParty/cocoa-oauth/GCOAuth.m
@@ -217,7 +217,7 @@ static BOOL GCOAuthUseHTTPSCookieStorage = YES;
     time_t t;
     time(&t);
     mktime(gmtime(&t));
-    return [NSString stringWithFormat:@"%u", (t + GCOAuthTimeStampOffset)];
+    return [NSString stringWithFormat:@"%ld", (t + GCOAuthTimeStampOffset)];
 }
 + (NSString *)queryStringFromParameters:(NSDictionary *)parameters {
     NSMutableArray *entries = [NSMutableArray array];


### PR DESCRIPTION
This fixes the:
"Format specifies type 'unsigned int' but the argument has type 'long'"
warning when using the llvm 4.0 compiler.
