### PR TITLE
Remove cookies when user click the 'Decline' link

### DIFF
--- a/evernote-sdk-ios/internal/ENOAuthViewController.m
+++ b/evernote-sdk-ios/internal/ENOAuthViewController.m
@@ -108,6 +108,22 @@
             [self.delegate oauthViewController:self receivedOAuthCallbackURL:request.URL];
         }
         return NO;
+    }else if([[request.HTTPMethod lowercaseString] isEqualToString:@"post"]){
+        
+        NSString *postBody = [NSString stringWithUTF8String:(const char *)[[request HTTPBody] bytes]];
+        NSRange range = [postBody rangeOfString:@"Decline"];
+        
+        //Decline Button
+        if(range.location != NSNotFound){
+            
+            // remove all cookies from the Evernote service
+            NSHTTPCookieStorage *cookieJar = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+            for (NSHTTPCookie *cookie in [cookieJar cookies]) {
+                if ([[cookie domain] hasSuffix: request.URL.host]) {
+                    [cookieJar deleteCookie: cookie];
+                }
+            }
+        }
     }
     return YES;
 }


### PR DESCRIPTION
Users have to work with OAuth's authentication UI in two step. 
1. User login with username & password
2. User authenticate the app ( Allow / Decline )

If the user make a cancel in the second step ( Click cancel after login, or click the decline link ), the interface will keep showing the second state. And, there will be no way for user to login with another account.

This patch will detect 'Decline' link clicked, remove Evernote's cookies, and redirect user back to the login UI.
