### PR TITLE
Allows arc compilation for iOS6

### DIFF
--- a/evernote-sdk-ios/EvernoteSession.m
+++ b/evernote-sdk-ios/EvernoteSession.m
@@ -106,7 +106,9 @@
 
 - (void)dealloc
 {
+#if !OS_OBJECT_USE_OBJC
     dispatch_release(_queue);
+#endif
 }
 
 - (id)init 


### PR DESCRIPTION
If using the iOS 6 SDK, ARC manages GDC queues, so this code is no longer valid.

This change ensures that the Evernote API will continue to compile with ARC and iOS 6.
