### PR TITLE
"dismissModalViewControllerAnimated" is replaced with "dismissViewControllerAnimated:completion:".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,17 @@
+# Xcode
+build/*
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
 xcuserdata
+profile
+*.moved-aside
+.DS_Store
+*~

--- a/UnitTests/EvernoteSessionTests.m
+++ b/UnitTests/EvernoteSessionTests.m
@@ -227,7 +227,7 @@
     [self.mockSession verify];
 
     // successful authentication will dismiss the modal popup
-    [[self.mockViewController expect] dismissModalViewControllerAnimated:YES];
+	[[self.mockViewController expect] dismissViewControllerAnimated:YES completion:nil];
     
     NSString *urlString = @"en-dummyaccount-1234://response?action=oauthCallback&oauth_token=en_oauth_test.12BF88D95B9.687474703A2F2F6C6F63616C686F73742F7E736574682F4544414D576562546573742F696E6465782E7068703F616374696F6E3D63616C6C6261636B.AEDE24F1FAFD67D267E78D27D14F01D3&oauth_verifier=0D6A636CD623302F8D69DBB8DF76D86E";
     [self.mockSession oauthViewController:nil receivedOAuthCallbackURL:[NSURL URLWithString:urlString]];

--- a/evernote-sdk-ios/EvernoteSession.m
+++ b/evernote-sdk-ios/EvernoteSession.m
@@ -450,7 +450,7 @@
 
 - (BOOL)handleOpenURL:(NSURL *)url
 {
-    [self.viewController dismissModalViewControllerAnimated:YES];
+	[self.viewController dismissViewControllerAnimated:YES completion:nil];
     // only handle our specific oauth_callback URLs
     if (![[url absoluteString] hasPrefix:[self oauthCallback]]) {
         return NO;
@@ -782,7 +782,7 @@
 
 - (void)oauthViewControllerDidCancel:(ENOAuthViewController *)sender
 {
-    [self.viewController dismissModalViewControllerAnimated:YES];    
+	[self.viewController dismissViewControllerAnimated:YES completion:nil];
 	[self completeAuthenticationWithError:nil];
 }
 
@@ -793,7 +793,7 @@
 
 - (void)oauthViewController:(ENOAuthViewController *)sender didFailWithError:(NSError *)error
 {
-    [self.viewController dismissModalViewControllerAnimated:YES];
+	[self.viewController dismissViewControllerAnimated:YES completion:nil];
     [self completeAuthenticationWithError:error];
 }
 
@@ -847,7 +847,7 @@
 
 - (void)oauthViewController:(ENOAuthViewController *)sender receivedOAuthCallbackURL:(NSURL *)url
 {
-    [self.viewController dismissModalViewControllerAnimated:YES];
+	[self.viewController dismissViewControllerAnimated:YES completion:nil];
     
     // OAuth step 3: got authorization from the user, now get a real token.
     NSDictionary *parameters = [EvernoteSession parametersFromQueryString:url.query];


### PR DESCRIPTION
"dismissModalViewControllerAnimated:" is deprecated in iOS6.
