### PR TITLE
Fix crash when OS_OBJECT_USE_OBJC=0 is set on build

### DIFF
--- a/evernote-sdk-ios/EvernoteSession.h
+++ b/evernote-sdk-ios/EvernoteSession.h
@@ -109,7 +109,11 @@ typedef NS_ENUM(NSInteger, ENSessionState) {
 @property (weak, nonatomic, readonly) NSString *webApiUrlPrefix;
 
 /** Shared dispatch queue for API operations. */
+#if !OS_OBJECT_USE_OBJC
 @property (nonatomic, readonly) dispatch_queue_t queue;
+#else
+@property (nonatomic, strong, readonly) dispatch_queue_t queue;
+#endif
 
 /** All the bootstrap profiles for the user. */
 @property (nonatomic, strong) NSArray* profiles;


### PR DESCRIPTION
I noticed my app always crash when build for iOS 6 with rubymotion.

At commit ec8b8ef OS_OBJECT_USE_OBJC check is added to EvernoteSession. The
declaration of queue should also check this flag, such that when
OS_OBJECT_USE_OBJC=1, the compiler treat queue as object (and thus retain it properly)
