### PR TITLE
Allows inclusion of AFNetworking in existing project.

### DIFF
--- a/evernote-sdk-ios/3rdParty/Thrift/transport/THTTPClient.m
+++ b/evernote-sdk-ios/3rdParty/Thrift/transport/THTTPClient.m
@@ -20,7 +20,13 @@
 #import "THTTPClient.h"
 #import "TTransportException.h"
 #import "TObjective-C.h"
+#ifdef _EVERNOTE_API_INCLUDES_AFNETWORKING_
+#import "AFNetworking.h"
+#define ENAFURLConnectionOperation AFURLConnectionOperation
+#else
 #import "ENAFURLConnectionOperation.h"
+#endif
+
 
 @interface THTTPClient ()
 

--- a/evernote-sdk-ios/3rdParty/Thrift/transport/THTTPClient.m
+++ b/evernote-sdk-ios/3rdParty/Thrift/transport/THTTPClient.m
@@ -20,6 +20,11 @@
 #import "THTTPClient.h"
 #import "TTransportException.h"
 #import "TObjective-C.h"
+
+/*
+ *If using AFNetworking alongside the Evernote API, you may exclude ENAFURLConnectionOperation and define
+ *_EVERNOTE_API_INCLUDES_AFNETWORKING_ in your precompiled header.
+*/
 #ifdef _EVERNOTE_API_INCLUDES_AFNETWORKING_
 #import "AFNetworking.h"
 #define ENAFURLConnectionOperation AFURLConnectionOperation


### PR DESCRIPTION
#### The issue

If a user uses the new SDK in a project that already uses AFNetworking, the inclusion of ENAFURLConnectionOperation creates compilation errors due to duplicated constants: 

eg:

```
duplicate symbol _AFNetworkingOperationDidStartNotification in:
    /Users/gduplooy/Library/Developer/Xcode/DerivedData/TestyAPp3-glukjkaxovgstdhfzghlnwocseqp/Build/Intermediates/TestyAPp3.build/Debug-iphonesimulator/TestyAPp3.build/Objects-normal/i386/AFURLConnectionOperation.o
    /Users/gduplooy/Library/Developer/Xcode/DerivedData/TestyAPp3-glukjkaxovgstdhfzghlnwocseqp/Build/Intermediates/TestyAPp3.build/Debug-iphonesimulator/TestyAPp3.build/Objects-normal/i386/ENAFURLConnectionOperation.o

```
#### Resolution

If we are already using AFNetworking, we can define a _EVERNOTE_API_INCLUDES_AFNETWORKING_ in our prefix.pch for our project, allowing us to use the Evernote SDK alongside AFNetworking.
