### PR TITLE
Add namespace to base64 category to prevent collision

### DIFF
--- a/evernote-sdk-ios/3rdParty/cocoa-oauth/ENGCOAuth.m
+++ b/evernote-sdk-ios/3rdParty/cocoa-oauth/ENGCOAuth.m
@@ -150,7 +150,7 @@ static BOOL GCOAuthUseHTTPSCookieStorage = YES;
     
     // base 64
     NSData *data = [NSData dataWithBytes:digest length:CC_SHA1_DIGEST_LENGTH];
-    return [data base64EncodedString];
+    return [data en_base64EncodedString];
     
 }
 - (NSString *)signatureBase {

--- a/evernote-sdk-ios/3rdParty/cocoa-oauth/NSData+ENBase64.h
+++ b/evernote-sdk-ios/3rdParty/cocoa-oauth/NSData+ENBase64.h
@@ -36,7 +36,7 @@ char *NewBase64Encode(
 
 @interface NSData (ENBase64)
 
-+ (NSData *)dataFromBase64String:(NSString *)aString;
-- (NSString *)base64EncodedString;
++ (NSData *)en_dataFromBase64String:(NSString *)aString;
+- (NSString *)en_base64EncodedString;
 
 @end

--- a/evernote-sdk-ios/3rdParty/cocoa-oauth/NSData+ENBase64.h
+++ b/evernote-sdk-ios/3rdParty/cocoa-oauth/NSData+ENBase64.h
@@ -23,12 +23,12 @@
 
 #import <Foundation/Foundation.h>
 
-void *NewBase64Decode(
+void *EnNewBase64Decode(
 	const char *inputBuffer,
 	size_t length,
 	size_t *outputLength);
 
-char *NewBase64Encode(
+char *EnNewBase64Encode(
 	const void *inputBuffer,
 	size_t length,
 	bool separateLines,

--- a/evernote-sdk-ios/3rdParty/cocoa-oauth/NSData+ENBase64.m
+++ b/evernote-sdk-ios/3rdParty/cocoa-oauth/NSData+ENBase64.m
@@ -76,7 +76,7 @@ static unsigned char base64DecodeLookup[256] =
 // returns the decoded buffer. Must be free'd by caller. Length is given by
 //	outputLength.
 //
-void *NewBase64Decode(
+void *EnNewBase64Decode(
 	const char *inputBuffer,
 	size_t length,
 	size_t *outputLength)
@@ -152,7 +152,7 @@ void *NewBase64Decode(
 // returns the encoded buffer. Must be free'd by caller. Length is given by
 //	outputLength.
 //
-char *NewBase64Encode(
+char *EnNewBase64Encode(
 	const void *buffer,
 	size_t length,
 	bool separateLines,
@@ -280,7 +280,7 @@ char *NewBase64Encode(
 {
 	NSData *data = [aString dataUsingEncoding:NSASCIIStringEncoding];
 	size_t outputLength;
-	void *outputBuffer = NewBase64Decode([data bytes], [data length], &outputLength);
+	void *outputBuffer = EnNewBase64Decode([data bytes], [data length], &outputLength);
 	NSData *result = [NSData dataWithBytes:outputBuffer length:outputLength];
 	free(outputBuffer);
 	return result;
@@ -299,7 +299,7 @@ char *NewBase64Encode(
 {
 	size_t outputLength = 0;
 	char *outputBuffer =
-		NewBase64Encode([self bytes], [self length], true, &outputLength);
+		EnNewBase64Encode([self bytes], [self length], true, &outputLength);
 	
 	NSString *result =
 		[[NSString alloc]

--- a/evernote-sdk-ios/3rdParty/cocoa-oauth/NSData+ENBase64.m
+++ b/evernote-sdk-ios/3rdParty/cocoa-oauth/NSData+ENBase64.m
@@ -276,7 +276,7 @@ char *NewBase64Encode(
 //
 // returns the autoreleased NSData representation of the base64 string
 //
-+ (NSData *)dataFromBase64String:(NSString *)aString
++ (NSData *)en_dataFromBase64String:(NSString *)aString
 {
 	NSData *data = [aString dataUsingEncoding:NSASCIIStringEncoding];
 	size_t outputLength;
@@ -295,7 +295,7 @@ char *NewBase64Encode(
 // returns an autoreleased NSString being the base 64 representation of the
 //	receiver.
 //
-- (NSString *)base64EncodedString
+- (NSString *)en_base64EncodedString
 {
 	size_t outputLength = 0;
 	char *outputBuffer =


### PR DESCRIPTION
I found when I add evernote sdk to the project, the system complain duplicate method name. 

I noticed in my project I have another file NSData+Base64.m having same implementations. It seems evernote version have a different filename but with same implementation, thus i rename the file to prevent collision.
