### PR TITLE
Needed headers are not copied to public header directory

### DIFF
--- a/evernote-sdk-ios.xcodeproj/project.pbxproj
+++ b/evernote-sdk-ios.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0B0DE6A61571978C00D7347A /* ENOAuthViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B0DE6A41571978C00D7347A /* ENOAuthViewController.h */; };
+		0B0DE6A61571978C00D7347A /* ENOAuthViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B0DE6A41571978C00D7347A /* ENOAuthViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0B2B9D621544944800E5BD44 /* EvernoteUserStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B2B9D601544944800E5BD44 /* EvernoteUserStore.h */; };
 		0B2B9D631544944800E5BD44 /* EvernoteUserStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B2B9D611544944800E5BD44 /* EvernoteUserStore.m */; };
 		0B2B9D641544944800E5BD44 /* EvernoteUserStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B2B9D611544944800E5BD44 /* EvernoteUserStore.m */; };
@@ -192,8 +192,8 @@
 		A9C555061671539A006E0020 /* EvernoteUserStore+Extras.h in Headers */ = {isa = PBXBuildFile; fileRef = A9C5550416715399006E0020 /* EvernoteUserStore+Extras.h */; };
 		A9C555071671539A006E0020 /* EvernoteUserStore+Extras.m in Sources */ = {isa = PBXBuildFile; fileRef = A9C555051671539A006E0020 /* EvernoteUserStore+Extras.m */; };
 		A9C555081671539A006E0020 /* EvernoteUserStore+Extras.m in Sources */ = {isa = PBXBuildFile; fileRef = A9C555051671539A006E0020 /* EvernoteUserStore+Extras.m */; };
-		A9D166C5169151D600043DA0 /* TObjective-C.h in Headers */ = {isa = PBXBuildFile; fileRef = A9D166C4169151D600043DA0 /* TObjective-C.h */; };
-		A9FDF718165C5C7200DC7E4B /* ENConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = A9FDF716165C5C7100DC7E4B /* ENConstants.h */; };
+		A9D166C5169151D600043DA0 /* TObjective-C.h in Headers */ = {isa = PBXBuildFile; fileRef = A9D166C4169151D600043DA0 /* TObjective-C.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A9FDF718165C5C7200DC7E4B /* ENConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = A9FDF716165C5C7100DC7E4B /* ENConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9FDF719165C5C7200DC7E4B /* ENConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = A9FDF717165C5C7100DC7E4B /* ENConstants.m */; };
 		A9FDF71B165C5D0300DC7E4B /* ENConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = A9FDF717165C5C7100DC7E4B /* ENConstants.m */; };
 /* End PBXBuildFile section */
@@ -820,6 +820,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A9FDF718165C5C7200DC7E4B /* ENConstants.h in Headers */,
 				0BB3D2451524EE62001C4534 /* EvernoteSession.h in Headers */,
 				0BB3D23A1524EE62001C4534 /* EDAM.h in Headers */,
 				0BB3D23B1524EE62001C4534 /* EDAMLimits.h in Headers */,
@@ -841,6 +842,8 @@
 				0B943F761525015500DB20A3 /* TMemoryBuffer.h in Headers */,
 				0B943F821525015500DB20A3 /* TTransport.h in Headers */,
 				0B943F831525015500DB20A3 /* TTransportException.h in Headers */,
+				A9D166C5169151D600043DA0 /* TObjective-C.h in Headers */,
+				0B0DE6A61571978C00D7347A /* ENOAuthViewController.h in Headers */,
 				0B943F521525015500DB20A3 /* ENGCOAuth.h in Headers */,
 				0B943F551525015500DB20A3 /* NSData+ENBase64.h in Headers */,
 				0B943F591525015500DB20A3 /* NSString+URLEncoding.h in Headers */,
@@ -851,14 +854,11 @@
 				0B345EBE1544633F00A1FDBF /* EvernoteNoteStore.h in Headers */,
 				0B2B9D621544944800E5BD44 /* EvernoteUserStore.h in Headers */,
 				0B2B9D6815449AEE00E5BD44 /* EvernoteSDK.h in Headers */,
-				0B0DE6A61571978C00D7347A /* ENOAuthViewController.h in Headers */,
-				A9FDF718165C5C7200DC7E4B /* ENConstants.h in Headers */,
 				A9C554FC16712F17006E0020 /* NSDate+EDAMAdditions.h in Headers */,
 				A9C55501167149B1006E0020 /* EvernoteNoteStore+Extras.h in Headers */,
 				A9C555061671539A006E0020 /* EvernoteUserStore+Extras.h in Headers */,
 				A92602BF1672B6DD00F01E63 /* NSData+EvernoteSDK.h in Headers */,
 				A92602C416740D5700F01E63 /* ENMLUtility.h in Headers */,
-				A9D166C5169151D600043DA0 /* TObjective-C.h in Headers */,
 				A96FE4D816A0958600F1AD8C /* EDAMNoteStoreClient+Utilities.h in Headers */,
 				A96FE4EE16A0A3DB00F1AD8C /* ENAFURLConnectionOperation.h in Headers */,
 				A9B1E86616C2242200D54760 /* KSForwardingWriter.h in Headers */,

--- a/evernote-sdk-ios.xcodeproj/project.pbxproj
+++ b/evernote-sdk-ios.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0B0DE6A61571978C00D7347A /* ENOAuthViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B0DE6A41571978C00D7347A /* ENOAuthViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0B2B9D621544944800E5BD44 /* EvernoteUserStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B2B9D601544944800E5BD44 /* EvernoteUserStore.h */; };
+		0B2B9D621544944800E5BD44 /* EvernoteUserStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B2B9D601544944800E5BD44 /* EvernoteUserStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0B2B9D631544944800E5BD44 /* EvernoteUserStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B2B9D611544944800E5BD44 /* EvernoteUserStore.m */; };
 		0B2B9D641544944800E5BD44 /* EvernoteUserStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B2B9D611544944800E5BD44 /* EvernoteUserStore.m */; };
 		0B2B9D6815449AEE00E5BD44 /* EvernoteSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B2B9D6615449AEE00E5BD44 /* EvernoteSDK.h */; };
@@ -56,7 +56,7 @@
 		0B943F831525015500DB20A3 /* TTransportException.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B943F4E1525015500DB20A3 /* TTransportException.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0B943F841525015500DB20A3 /* TTransportException.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B943F4F1525015500DB20A3 /* TTransportException.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		0B943F851525015500DB20A3 /* TTransportException.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B943F4F1525015500DB20A3 /* TTransportException.m */; settings = {COMPILER_FLAGS = "-w"; }; };
-		0B98592815432592007D7D37 /* ENAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B98592215432592007D7D37 /* ENAPI.h */; };
+		0B98592815432592007D7D37 /* ENAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B98592215432592007D7D37 /* ENAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0B98592915432592007D7D37 /* ENAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B98592315432592007D7D37 /* ENAPI.m */; };
 		0B98592A15432592007D7D37 /* ENAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B98592315432592007D7D37 /* ENAPI.m */; };
 		0B98592B15432592007D7D37 /* ENCredentials.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B98592415432592007D7D37 /* ENCredentials.h */; };
@@ -844,15 +844,15 @@
 				0B943F831525015500DB20A3 /* TTransportException.h in Headers */,
 				A9D166C5169151D600043DA0 /* TObjective-C.h in Headers */,
 				0B0DE6A61571978C00D7347A /* ENOAuthViewController.h in Headers */,
+				0B2B9D621544944800E5BD44 /* EvernoteUserStore.h in Headers */,
+				0B98592815432592007D7D37 /* ENAPI.h in Headers */,
 				0B943F521525015500DB20A3 /* ENGCOAuth.h in Headers */,
 				0B943F551525015500DB20A3 /* NSData+ENBase64.h in Headers */,
 				0B943F591525015500DB20A3 /* NSString+URLEncoding.h in Headers */,
 				0BF0CF81152E25E1003D6115 /* SSKeychain.h in Headers */,
-				0B98592815432592007D7D37 /* ENAPI.h in Headers */,
 				0B98592B15432592007D7D37 /* ENCredentials.h in Headers */,
 				0B98592E15432592007D7D37 /* ENCredentialStore.h in Headers */,
 				0B345EBE1544633F00A1FDBF /* EvernoteNoteStore.h in Headers */,
-				0B2B9D621544944800E5BD44 /* EvernoteUserStore.h in Headers */,
 				0B2B9D6815449AEE00E5BD44 /* EvernoteSDK.h in Headers */,
 				A9C554FC16712F17006E0020 /* NSDate+EDAMAdditions.h in Headers */,
 				A9C55501167149B1006E0020 /* EvernoteNoteStore+Extras.h in Headers */,


### PR DESCRIPTION
The documentation mentions you need to import `ENConstants.h`, but the header is added to the "project" area of the copy headers step, so it's not publicly available. 
