### PR TITLE
Hide the libxml dependency inside implementation files

### DIFF
--- a/evernote-sdk-ios/Utilities/ENMLWriter/ENXMLDTD.h
+++ b/evernote-sdk-ios/Utilities/ENMLWriter/ENXMLDTD.h
@@ -28,12 +28,8 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <libxml/tree.h>
 
-@interface ENXMLDTD : NSObject {
-  xmlDtdPtr _dtd;
-  NSString * _docTypeDeclaration;
-}
+@interface ENXMLDTD : NSObject
 
 @property ( strong, nonatomic) NSString *docTypeDeclaration;
 
@@ -45,9 +41,6 @@
 
 
 - (id) initWithContentsOfFile:(NSString *)file;
-
-- (xmlEntityPtr) xmlEntityNamed:(NSString *)name;
-- (xmlElementPtr) xmlElementNamed:(NSString *)name;
 
 - (BOOL) isElementLegal:(NSString *)name;
 - (NSDictionary*) sanitizedAttributes:(NSDictionary*)attribDict

--- a/evernote-sdk-ios/Utilities/ENMLWriter/ENXMLDTD.m
+++ b/evernote-sdk-ios/Utilities/ENMLWriter/ENXMLDTD.m
@@ -29,7 +29,8 @@
 
 #import "ENXMLDTD.h"
 #import "ENXMLUtils.h"
-#include <libxml/parserInternals.h>
+#import <libxml/parserInternals.h>
+#import <libxml/tree.h>
 
 xmlExternalEntityLoader defaultExternalEntityLoader = NULL;
 static xmlParserInputPtr	enxmlExternalEntityLoader	(const char * URL, 
@@ -63,7 +64,10 @@ static xmlParserInputPtr	enxmlExternalEntityLoader	(const char * URL,
   return ret;
 }
 
-@implementation ENXMLDTD
+@implementation ENXMLDTD {
+  xmlDtdPtr _dtd;
+  NSString * _docTypeDeclaration;
+}
 
 @synthesize docTypeDeclaration = _docTypeDeclaration;
 

--- a/evernote-sdk-ios/Utilities/ENMLWriter/ENXMLUtils.h
+++ b/evernote-sdk-ios/Utilities/ENMLWriter/ENXMLUtils.h
@@ -29,6 +29,7 @@
 
 
 #import <Foundation/Foundation.h>
+#import <libxml/xmlstring.h>
 
 static inline NSString * NSStringFromXmlCharWithLength( const xmlChar * ch, size_t length) {
   if (ch == NULL) {

--- a/evernote-sdk-ios/Utilities/ENMLWriter/ENXMLWriter.h
+++ b/evernote-sdk-ios/Utilities/ENMLWriter/ENXMLWriter.h
@@ -28,23 +28,12 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <libxml/xmlwriter.h>
 
 #import "ENXMLDTD.h"
 
 @protocol ENXMLWriterDelegate;
 
-@interface ENXMLWriter : NSObject {
-  id<ENXMLWriterDelegate> __weak _delegate;
-  NSMutableString *_contents;
-  
-  xmlTextWriterPtr _xmlWriter;
-  xmlOutputBufferPtr _xmlOutputBuffer;
-
-  ENXMLDTD * _dtd;
-  NSString * _currentElementName;
-  NSUInteger _openElementCount;
-}
+@interface ENXMLWriter : NSObject
 
 @property (weak, nonatomic) id<ENXMLWriterDelegate> delegate;
 

--- a/evernote-sdk-ios/Utilities/ENMLWriter/ENXMLWriter.m
+++ b/evernote-sdk-ios/Utilities/ENMLWriter/ENXMLWriter.m
@@ -29,6 +29,7 @@
 
 #import "ENXMLWriter.h"
 #import "ENXMLUtils.h"
+#import <libxml/xmlwriter.h>
 
 static void CheckXMLResult(int result, NSString *blah) {
   if (result < 0) {
@@ -49,7 +50,17 @@ static void CheckXMLResult(int result, NSString *blah) {
 @property ( strong, nonatomic) NSString *currentElementName;
 @end
 
-@implementation ENXMLWriter
+@implementation ENXMLWriter {
+  id<ENXMLWriterDelegate> __weak _delegate;
+  NSMutableString *_contents;
+  
+  xmlTextWriterPtr _xmlWriter;
+  xmlOutputBufferPtr _xmlOutputBuffer;
+  
+  ENXMLDTD * _dtd;
+  NSString * _currentElementName;
+  NSUInteger _openElementCount;
+}
 
 @synthesize currentElementName = _currentElementName;
 


### PR DESCRIPTION
This makes packaging the Evernote SDK as a static library easier since the app target doesn’t have to add  `${SDKROOT}/usr/include/libxml2` to the Header Search Paths.
