### PR TITLE
Changed receiver of dismissal call in OAuth flow.

### DIFF
--- a/SQEvernote-SDK-iOS.podspec
+++ b/SQEvernote-SDK-iOS.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
-  s.name     = 'Evernote-SDK-iOS'
+  s.name     = 'SQEvernote-SDK-iOS'
   s.version  = '1.3.1'
   s.platform = :ios,'5.0'
   s.license  = 'https://github.com/evernote/evernote-sdk-ios/blob/master/LICENSE'
   s.summary  = 'Evernote SDK for iOS.'
-  s.homepage = 'https://github.com/evernote/evernote-sdk-ios'
+  s.homepage = 'https://github.com/Squarespace/evernote-sdk-ios'
   s.authors  = { 'Evernote' => 'devsupport@evernote.com' }
   s.requires_arc = true
-  s.source   = { :git => 'https://github.com/evernote/evernote-sdk-ios.git', :tag => '1.3.1' }
+  s.source   = { :git => 'https://github.com/Squarespace/evernote-sdk-ios.git', :tag => 'squarespace.1.3.1' }
   s.source_files = 'evernote-sdk-ios/*.{h,m}',
     'evernote-sdk-ios/{EDAM,Utilities,internal}/**/*.{h,m}',
     'evernote-sdk-ios/3rdParty/{AFNetworking,KSHTMLWriter,NSString+URLEncoding,Thrift,cocoa-oauth}/**/*.{h,m}'

--- a/evernote-sdk-ios/EvernoteSession.m
+++ b/evernote-sdk-ios/EvernoteSession.m
@@ -986,7 +986,7 @@
 
 - (void)oauthViewController:(ENOAuthViewController *)sender receivedOAuthCallbackURL:(NSURL *)url
 {
-    [self.viewController dismissViewControllerAnimated:YES completion:^{
+    [sender dismissViewControllerAnimated:YES completion:^{
         [self getOAuthTokenForURL:url];
     }];
 }

--- a/evernote-sdk-ios/EvernoteSession.m
+++ b/evernote-sdk-ios/EvernoteSession.m
@@ -901,7 +901,7 @@
 
 - (void)oauthViewControllerDidCancel:(ENOAuthViewController *)sender
 {
-    [self.viewController dismissViewControllerAnimated:YES completion:^{
+    [sender dismissViewControllerAnimated:YES completion:^{
         NSError* error = [NSError errorWithDomain:EvernoteSDKErrorDomain code:EvernoteSDKErrorCode_USER_CANCELLED userInfo:nil];
         [self completeAuthenticationWithError:error];
     }];
@@ -914,7 +914,7 @@
 
 - (void)oauthViewController:(ENOAuthViewController *)sender didFailWithError:(NSError *)error
 {
-    [self.viewController dismissViewControllerAnimated:YES completion:^{
+    [sender dismissViewControllerAnimated:YES completion:^{
         [self completeAuthenticationWithError:error];
     }];
    


### PR DESCRIPTION
Changed the receiver of dismissViewController: call from self.viewController to the modally presented oauth view controller. This prevents incorrect dismissal if self.viewController itself is presented modally.
