### PR TITLE
OAuth view controller dismissal fix

### DIFF
--- a/evernote-sdk-ios/EvernoteSession.m
+++ b/evernote-sdk-ios/EvernoteSession.m
@@ -901,7 +901,7 @@
 
 - (void)oauthViewControllerDidCancel:(ENOAuthViewController *)sender
 {
-    [self.viewController dismissViewControllerAnimated:YES completion:^{
+    [sender dismissViewControllerAnimated:YES completion:^{
         NSError* error = [NSError errorWithDomain:EvernoteSDKErrorDomain code:EvernoteSDKErrorCode_USER_CANCELLED userInfo:nil];
         [self completeAuthenticationWithError:error];
     }];
@@ -914,7 +914,7 @@
 
 - (void)oauthViewController:(ENOAuthViewController *)sender didFailWithError:(NSError *)error
 {
-    [self.viewController dismissViewControllerAnimated:YES completion:^{
+    [sender dismissViewControllerAnimated:YES completion:^{
         [self completeAuthenticationWithError:error];
     }];
    
@@ -986,7 +986,7 @@
 
 - (void)oauthViewController:(ENOAuthViewController *)sender receivedOAuthCallbackURL:(NSURL *)url
 {
-    [self.viewController dismissViewControllerAnimated:YES completion:^{
+    [sender dismissViewControllerAnimated:YES completion:^{
         [self getOAuthTokenForURL:url];
     }];
 }


### PR DESCRIPTION
Changed the receiver of dismissViewController: calls from self.viewController to the modally presented OAuth view controller. This prevents incorrect dismissal if self.viewController itself is presented modally.
