### PR TITLE
Fix milliseconds lost in timestamp

### DIFF
--- a/evernote-sdk-ios/Utilities/NSDate+EDAMAdditions.m
+++ b/evernote-sdk-ios/Utilities/NSDate+EDAMAdditions.m
@@ -38,7 +38,7 @@
 
 - (int64_t) enedamTimestamp
 {
-    return trunc([self timeIntervalSince1970]) * 1000;
+    return trunc([self timeIntervalSince1970] * 1000);
 }
 
 @end


### PR DESCRIPTION
Applying `trunk` before multiple the time interval with 1000 discarded the millisecond unit.
So, trunk after multiple.
